### PR TITLE
Removing spaces

### DIFF
--- a/12-go-kit-1/users/Dockerfile
+++ b/12-go-kit-1/users/Dockerfile
@@ -5,8 +5,8 @@ RUN mkdir -p /go/src/github.com/plutov/packagemain/12-go-kit-1
 ADD . /go/src/github.com/plutov/packagemain/12-go-kit-1
 WORKDIR /go/src/github.com/plutov/packagemain/12-go-kit-1/users
 
-RUN go get  -t -v ./...
-RUN go get  github.com/canthefason/go-watcher
+RUN go get -t -v ./...
+RUN go get github.com/canthefason/go-watcher
 RUN go install github.com/canthefason/go-watcher/cmd/watcher
 
-ENTRYPOINT  watcher -run github.com/plutov/packagemain/12-go-kit-1/users/cmd  -watch github.com/plutov/packagemain/12-go-kit-1/users
+ENTRYPOINT watcher -run github.com/plutov/packagemain/12-go-kit-1/users/cmd -watch github.com/plutov/packagemain/12-go-kit-1/users


### PR DESCRIPTION
In line 9, 10, 12 spaces are used twice which causes error. For example, RUN go get  github.com/canthefason/go-watcher there are two space after get which will cause error