### PR TITLE
Update README.md

### DIFF
--- a/11-oauth2/README.md
+++ b/11-oauth2/README.md
@@ -35,6 +35,7 @@ We'll do everything in 1 main.go file, and register 3 URL handlers:
 
 ```
 go get golang.org/x/oauth2
+go get cloud.google.com/go/compute/metadata
 ```
 
 We save google client id and secret in env variables and only use os.Getenv in the code.


### PR DESCRIPTION
Hi there, I tried `go run` using the golang:latest Docker container, got the error below.

Using `go get` to get the package fixes the issue, hence this PR.

    root@af6dbfb4a0f1:/mnt# go run main.go 
    /go/src/golang.org/x/oauth2/google/default.go:17:2: cannot find package "cloud.google.com/go/compute/metadata" in any of:
        /usr/local/go/src/cloud.google.com/go/compute/metadata (from $GOROOT)
        /go/src/cloud.google.com/go/compute/metadata (from $GOPATH)