### PR TITLE
Fix webcam.Read img gocv type error

### DIFF
--- a/05-gocv-machinebox/README.md
+++ b/05-gocv-machinebox/README.md
@@ -19,13 +19,15 @@ Now to be able to capture video and recognize faces from the web camera we have 
 brew install opencv3
 ```
 
-Then we need to set someenvironment variables:
+> Edit: As of July 2019, the above brew command installs opencv default version which is OpenCV4. You probably won't need to set the following env variables anymore.
+
+Then we need to set some environment variables:
 
 ```
 source $GOPATH/src/gocv.io/x/gocv/env.sh
 ```
 
-On https://gocv.io/getting-started/osx/ you can find how to install it on Mac. To verify that GoCV works fine we can run:
+To verify that GoCV works fine we can run:
 
 ```
 go run $GOPATH/src/gocv.io/x/gocv/cmd/version/main.go
@@ -65,7 +67,7 @@ func main() {
 	defer window.Close()
 
 	for {
-		if ok := webcam.Read(img); !ok || img.Empty() {
+		if ok := webcam.Read(&img); !ok || img.Empty() {
 			log.Print("cannot read webcam")
 			continue
 		}
@@ -105,8 +107,8 @@ for {
 		// draw rectangle for the face
 		size := gocv.GetTextSize("I don't know you", gocv.FontHersheyPlain, 3, 2)
 		pt := image.Pt(r.Min.X+(r.Min.X/2)-(size.X/2), r.Min.Y-2)
-		gocv.PutText(img, "I don't know you", pt, gocv.FontHersheyPlain, 3, blue, 2)
-		gocv.Rectangle(img, r, blue, 3)
+		gocv.PutText(&img, "I don't know you", pt, gocv.FontHersheyPlain, 3, blue, 2)
+		gocv.Rectangle(&img, r, blue, 3)
 	}
 
 	...

--- a/05-gocv-machinebox/README.md
+++ b/05-gocv-machinebox/README.md
@@ -27,7 +27,7 @@ Then we need to set some environment variables:
 source $GOPATH/src/gocv.io/x/gocv/env.sh
 ```
 
-To verify that GoCV works fine we can run:
+On https://gocv.io/getting-started/macos/ you can find how to install it on Mac. To verify that GoCV works fine we can run:
 
 ```
 go run $GOPATH/src/gocv.io/x/gocv/cmd/version/main.go

--- a/05-gocv-machinebox/main.go
+++ b/05-gocv-machinebox/main.go
@@ -40,7 +40,7 @@ func main() {
 	defer classifier.Close()
 
 	for {
-		if ok := webcam.Read(img); !ok || img.Empty() {
+		if ok := webcam.Read(&img); !ok || img.Empty() {
 			log.Print("cannot read webcam")
 			continue
 		}
@@ -72,8 +72,8 @@ func main() {
 			// draw rectangle for the face
 			size := gocv.GetTextSize(caption, gocv.FontHersheyPlain, 3, 2)
 			pt := image.Pt(r.Min.X+(r.Min.X/2)-(size.X/2), r.Min.Y-2)
-			gocv.PutText(img, caption, pt, gocv.FontHersheyPlain, 3, blue, 2)
-			gocv.Rectangle(img, r, blue, 3)
+			gocv.PutText(&img, caption, pt, gocv.FontHersheyPlain, 3, blue, 2)
+			gocv.Rectangle(&img, r, blue, 3)
 		}
 
 		// show the image in the window, and wait 100ms


### PR DESCRIPTION
As I was experimenting with this nice video tutorial, I got a few errors and differences that i'd like to fix for other people's use
 
<img width="804" alt="Screen Shot 2019-07-30 at 21 43 04" src="https://user-images.githubusercontent.com/25172711/62161726-218cb500-b317-11e9-8593-e3e06d43cb2f.png">

<img width="600" alt="Screen Shot 2019-07-30 at 21 42 21" src="https://user-images.githubusercontent.com/25172711/62161696-146fc600-b317-11e9-86cb-3eca535ccd49.png">
