### PR TITLE
tcp chat improvements

### DIFF
--- a/20-tcp-chat/chat/server.go
+++ b/20-tcp-chat/chat/server.go
@@ -88,7 +88,7 @@ func (s *server) listRooms(c *client) {
 }
 
 func (s *server) msg(c *client, args []string) {
-	msg := strings.Join(args[1:len(args)], " ")
+	msg := strings.Join(args[1:], " ")
 	c.room.broadcast(c, c.nick+": "+msg)
 }
 

--- a/20-tcp-chat/chat/server.go
+++ b/20-tcp-chat/chat/server.go
@@ -23,7 +23,7 @@ func (s *server) run() {
 	for cmd := range s.commands {
 		switch cmd.id {
 		case CMD_NICK:
-			s.nick(cmd.client, cmd.args[1])
+			s.nick(cmd.client, cmd.args)
 		case CMD_JOIN:
 			s.join(cmd.client, cmd.args[1])
 		case CMD_ROOMS:
@@ -48,7 +48,13 @@ func (s *server) newClient(conn net.Conn) {
 	c.readInput()
 }
 
-func (s *server) nick(c *client, nick string) {
+func (s *server) nick(c *client, args []string) {
+	nick := strings.TrimSpace(strings.Join(args[1:], " "))
+	if nick == "" {
+		c.err(fmt.Errorf("you must provide a nickname"))
+
+		return
+	}
 	c.nick = nick
 	c.msg(fmt.Sprintf("all right, I will call you %s", nick))
 }


### PR DESCRIPTION
This PR introduces nickname validation by rejecting attempts to set the nickname to an empty string ("").

It also allows nicknames with spaces ("Tom on the Internet")

Finally, it removes an unnecessary termination index.
