### PR TITLE
separate creating client from reading input

### DIFF
--- a/20-tcp-chat/chat/main.go
+++ b/20-tcp-chat/chat/main.go
@@ -24,6 +24,7 @@ func main() {
 			continue
 		}
 
-		go s.newClient(conn)
+		c := s.newClient(conn)
+		go c.readInput()
 	}
 }

--- a/20-tcp-chat/chat/server.go
+++ b/20-tcp-chat/chat/server.go
@@ -36,16 +36,14 @@ func (s *server) run() {
 	}
 }
 
-func (s *server) newClient(conn net.Conn) {
+func (s *server) newClient(conn net.Conn) *client {
 	log.Printf("new client has joined: %s", conn.RemoteAddr().String())
 
-	c := &client{
+	return &client{
 		conn:     conn,
 		nick:     "anonymous",
 		commands: s.commands,
 	}
-
-	c.readInput()
 }
 
 func (s *server) nick(c *client, nick string) {


### PR DESCRIPTION
This PR separates the creation of the client from the reading of input.
This follows the same pattern as creating a new server and then running that server.
