### PR TITLE
Add more reliable draining

### DIFF
--- a/14-go-modules-docker/httpserver/go.mod
+++ b/14-go-modules-docker/httpserver/go.mod
@@ -1,3 +1,15 @@
 module github.com/plutov/packagemain/14-go-modules-docker/httpserver
 
+go 1.22.2
+
 require github.com/sirupsen/logrus v1.2.0
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/konsorten/go-windows-terminal-sequences v1.0.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/objx v0.1.1 // indirect
+	github.com/stretchr/testify v1.2.2 // indirect
+	golang.org/x/crypto v0.0.0-20180904163835-0709b304e793 // indirect
+	golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33 // indirect
+)

--- a/graceful-shutdown/graceful-shutdown/main.go
+++ b/graceful-shutdown/graceful-shutdown/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"log"
+	"net"
 	"net/http"
 	"os"
 	"os/signal"
@@ -16,18 +17,41 @@ import (
 var wg sync.WaitGroup
 
 func main() {
-	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM)
-	defer stop()
+	ctx, cancel := context.WithCancel(context.Background())
+	// not necessary to manually cancel with RegisterOnShutdown(cancel) below
+	// defer cancel()
+	signalCtx, signalCtxStop := signal.NotifyContext(ctx,
+		os.Interrupt,    // interrupt = SIGINT = Ctrl+C
+		syscall.SIGQUIT, // Ctrl-\
+		syscall.SIGTERM, // "the normal way to politely ask a program to terminate"
+	)
+	defer signalCtxStop()
 
 	redisdb := redis.NewClient(&redis.Options{
 		Addr: os.Getenv("REDIS_ADDR"),
 	})
 
+	// inherit from signal cancellation context
 	server := http.Server{
-		Addr: ":8080",
+		Addr:        ":8080",
+		BaseContext: func(_ net.Listener) context.Context { return signalCtx },
 	}
 
+	// server.RegisterOnShutdown registers a function to call on Shutdown.
+	// This can be used to gracefully shutdown connections that have
+	// undergone ALPN protocol upgrade (HTTP2 or HTTP3)
+	// or that have been hijacked (websockets).
+	//
+	// The RegisterOnShutdown's argument function should start
+	// protocol-specific graceful shutdown,
+	// but should not wait for shutdown to complete.
+	//
+	// Also needed if your BaseContext is more complex you might want
+	// to use this instead of calling cancel manually
+	server.RegisterOnShutdown(cancel)
+
 	http.HandleFunc("/incr", func(w http.ResponseWriter, r *http.Request) {
+		//TODO: No longer necessary
 		wg.Add(1)
 		go processRequest(redisdb)
 		w.WriteHeader(http.StatusOK)
@@ -37,13 +61,19 @@ func main() {
 	go server.ListenAndServe()
 
 	// listen for the interrupt signal.
-	<-ctx.Done()
+	<-signalCtx.Done()
 
-	// stop the server
-	if err := server.Shutdown(context.Background()); err != nil {
+	// Give outstanding requests a deadline for completion.
+	const timeout = 5 * time.Second
+	shutdownCtx, shutdownRelease := context.WithTimeout(signalCtx, timeout)
+	defer shutdownRelease()
+
+	// signalCtxStop the server
+	if err := server.Shutdown(shutdownCtx); err != nil {
 		log.Fatalf("could not shutdown: %v\n", err)
 	}
 
+	//TODO: No longer necessary
 	// wait for all goroutines to finish
 	wg.Wait()
 
@@ -54,6 +84,7 @@ func main() {
 }
 
 func processRequest(redisdb *redis.Client) {
+	//TODO: No longer necessary
 	defer wg.Done()
 
 	// simulate some business logic here


### PR DESCRIPTION
Incrementing the waitgroup for every request is not panic-proof, and will be a problem if you have 1000s of requests per second.

Also, you need to actually RegisterOnShutdown for websockets and HTTP/2 and HTTP/3