### PR TITLE
30: return when client has disconnected

### DIFF
--- a/30-sse/main.go
+++ b/30-sse/main.go
@@ -39,6 +39,7 @@ func sseHandler(w http.ResponseWriter, r *http.Request) {
 		select {
 		case <-clientGone:
 			fmt.Println("client has disconnected")
+			return
 		case <-memT.C:
 			m, err := mem.VirtualMemory()
 			if err != nil {


### PR DESCRIPTION
The PR fixed a bug: when a client gets disconnected, the loop repeats excessively and fails with the error:

```
...
client has disconnected
client has disconnected
client has disconnected
client has disconnected
client has disconnected
client has disconnected
client has disconnected
client has disconnected
client has disconnected
client has disconnected
2025/02/06 17:47:12 unable to write: write tcp 127.0.0.1:8080->127.0.0.1:60552: write: broken pipe
```