### PR TITLE
13: use parent context

### DIFF
--- a/13-go-kit-2/users/pkg/service/service.go
+++ b/13-go-kit-2/users/pkg/service/service.go
@@ -20,7 +20,7 @@ type basicUsersService struct {
 
 func (b *basicUsersService) Create(ctx context.Context, email string) error {
 	// TODO: Add code to create a user
-	reply, err := b.notificatorServiceClient.SendEmail(context.Background(), &pb.SendEmailRequest{
+	reply, err := b.notificatorServiceClient.SendEmail(ctx, &pb.SendEmailRequest{
 		Email:   email,
 		Content: "Hi! Thank you for registration...",
 	})


### PR DESCRIPTION
It's better to use inherited `ctx` instead of `context.Background()` in the `notificatorServiceClient.SendEmail`.