### PR TITLE
testcontainers-demo,urlshortener: fix buildtag

### DIFF
--- a/testcontainers-demo/integration_test.go
+++ b/testcontainers-demo/integration_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 package main
 

--- a/testcontainers-demo/realdeps_test.go
+++ b/testcontainers-demo/realdeps_test.go
@@ -1,5 +1,4 @@
 //go:build realdeps
-// +build realdeps
 
 package main
 

--- a/urlshortener/integration_test.go
+++ b/urlshortener/integration_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 package main
 


### PR DESCRIPTION
This PR removes unnecessary build tags by running the command:

```sh
go fix -fix buildtag ./...
```