### PR TITLE
ulid: handle err with must

### DIFF
--- a/ulid/main.go
+++ b/ulid/main.go
@@ -16,7 +16,7 @@ func main() {
 	addr := "postgres://postgres:pass@localhost:5432/postgres"
 	conn, err := pgx.Connect(ctx, addr)
 	if err != nil {
-		fmt.Printf("unable to	connect to the database: %v\n", err)
+		fmt.Printf("unable to connect to the database: %v\n", err)
 		os.Exit(1)
 	}
 	defer conn.Close(ctx)
@@ -32,28 +32,27 @@ CREATE TABLE IF NOT EXISTS ulid_test (
 		os.Exit(1)
 	}
 
-	insertUUID(ctx, conn, "1")
-	insertUUID(ctx, conn, "2")
-	insertUUID(ctx, conn, "3")
-	insertUUID(ctx, conn, "4")
-	insertUUID(ctx, conn, "5")
+	must(insertUUID(ctx, conn, "1"))
+	must(insertUUID(ctx, conn, "2"))
+	must(insertUUID(ctx, conn, "3"))
+	must(insertUUID(ctx, conn, "4"))
+	must(insertUUID(ctx, conn, "5"))
 
-	insertULID(ctx, conn, "1")
-	insertULID(ctx, conn, "2")
-	insertULID(ctx, conn, "3")
-	insertULID(ctx, conn, "4")
-	insertULID(ctx, conn, "5")
+	must(insertULID(ctx, conn, "1"))
+	must(insertULID(ctx, conn, "2"))
+	must(insertULID(ctx, conn, "3"))
+	must(insertULID(ctx, conn, "4"))
+	must(insertULID(ctx, conn, "5"))
 }
 
 func insertUUID(ctx context.Context, conn *pgx.Conn, value string) error {
 	id := uuid.New()
 	_, err := conn.Exec(ctx, "INSERT INTO ulid_test (id, value, kind) VALUES ($1, $2, 'uuid')", id, value)
 	if err != nil {
-		fmt.Printf("unable to insert UUID: %v\n", err)
-		return err
+		return fmt.Errorf("unable to insert UUID: %w", err)
 	}
 
-	fmt.Printf("Inserted UUID: %s\n", id.String())
+	fmt.Printf("Inserted UUID: %s\n", id)
 
 	return nil
 }
@@ -63,11 +62,16 @@ func insertULID(ctx context.Context, conn *pgx.Conn, value string) error {
 	// as you can see, we don't need to format the ULID as a string, it can be used directly
 	_, err := conn.Exec(ctx, "INSERT INTO ulid_test (id, value, kind) VALUES ($1, $2, 'ulid')", id, value)
 	if err != nil {
-		fmt.Printf("unable to insert ULID: %v\n", err)
-		return err
+		return fmt.Errorf("unable to insert ULID: %w", err)
 	}
 
-	fmt.Printf("Inserted ULID: %s\n", id.String())
+	fmt.Printf("Inserted ULID: %s\n", id)
 
 	return nil
+}
+
+func must(err error) {
+	if err != nil {
+		panic(err)
+	}
 }


### PR DESCRIPTION
It's weird that `insertUUID` and `insertULID` return an error, but no one handles it.